### PR TITLE
fix single logs having > 50.000 lines

### DIFF
--- a/linbo/patch_registry.sh
+++ b/linbo/patch_registry.sh
@@ -18,7 +18,7 @@ else
 fi
 
 # this generates a LOT of debugging messages
-DEBUG="-v"
+DEBUG=""
 hive=""
 logfile="/tmp/output"
 


### PR DESCRIPTION
remove reged -v option to prevent logs > 50.000 lines
