### PR TITLE
remove unnecessary entry in conf/initramfs.conf

### DIFF
--- a/conf/initramfs.conf
+++ b/conf/initramfs.conf
@@ -1,7 +1,5 @@
 # $Id: initramfs.conf 1266 2012-01-28 17:17:38Z tschmitt $
 #
-# root directory
-dir / 755 0 0
 
 # busybox
 dir /bin 755 0 0


### PR DESCRIPTION
cpio strips the leading / resulting in empty filename which throws a error. creating the root directory is not necessary as it gets created by the kernel already. (+ cpio is not going to create it because it is just a empty entry for cpio as mentioned before, anways.)
