### PR TITLE
add options "-nomake examples" and "-nomake demos" to build_qt

### DIFF
--- a/linbo_gui/build_qt
+++ b/linbo_gui/build_qt
@@ -54,6 +54,8 @@
  -no-mouse-vr41xx \
  -no-mouse-tslib \
  -no-glib \
+ -nomake examples \
+ -nomake demos \
   )
 ( cd qt-embedded-linux-opensource-src-4.5.2
   export QTDIR=`pwd`


### PR DESCRIPTION
without these options, qt_build creates an examples folder of 13GB(!) and a demos folder of 1,3GB. these folders are not necessary for the linbo build, speeding the build up very much.
