### PR TITLE
fix for trac-ticket #146, update-linbofs generated a false password hash

### DIFF
--- a/share/update-linbofs.sh
+++ b/share/update-linbofs.sh
@@ -85,7 +85,7 @@ bailout() {
 
 # grep linbo rsync password to sync it with linbo account
 [ ! -s /etc/rsyncd.secrets ] && bailout "/etc/rsyncd.secrets not found!"
-linbo_passwd=`grep ^linbo /etc/rsyncd.secrets | awk -F\: '{ print $2 }'`
+linbo_passwd=`grep ^linbo /etc/rsyncd.secrets | cut -d ":" -f2 | tr -d '\n'`
 if [ -z "$linbo_passwd" ]; then
  bailout "Cannot read linbo password from /etc/rsyncd.secrets!"
 else


### PR DESCRIPTION
The linbo password hash is generated using 
linbo_passwd=`grep ^linbo /etc/rsyncd.secrets | awk -F\: '{ print $2 }'`
linbo_md5passwd=`echo -n $linbo_passwd | md5sum | awk '{ print $1 }'`
The generated hash is false, as you can easily test using echo -n "password" | md5sum.
Reason for this is that awk always appends a newline to it's output, which then corrupts the password.
You can easily fix the problem like this:
linbo_passwd=`grep ^linbo /etc/rsyncd.secrets | cut -d ":" -f2 | tr -d '\n' | md5sum`
I also switched to the less expensive (+ this also is the tool dedicated for this operation) cut instead of awk.
