### PR TITLE
fix /proc/cmdline parsing

### DIFF
--- a/linbo/init.sh
+++ b/linbo/init.sh
@@ -51,7 +51,9 @@ isinteger () {
 
 # DMA
 enable_dma(){
- case "$CMDLINE" in *\ nodma*) return 0 ;; esac
+ for arg in $CMDLINE; do
+   case $arg in nodma) return 0 ;; esac
+ done
  for d in $(cd /proc/ide 2>/dev/null && echo hd[a-z]); do
   if test -d /proc/ide/$d; then
    MODEL="$(cat /proc/ide/$d/model 2>/dev/null)"


### PR DESCRIPTION
`case "$CMDLINE" in *\ nodma*) return 0 ;; esac` won't work when there is no preceding space (which there isn't if there is no other command before). Also, this is going to wrongfully parse all arguments which only START with `nodma`, no matter what they end with.
