### PR TITLE
fix /proc/cmdline parsing

### DIFF
--- a/linbo/init.sh
+++ b/linbo/init.sh
@@ -85,17 +85,17 @@ init_setup(){
  CMDLINE="$(cat /proc/cmdline)"
  # deprecated
  #case "$CMDLINE" in *\ useide*) useide=yes;; esac
- case "$CMDLINE" in *\ debug*) debug=yes;; esac
- case "$CMDLINE" in *\ nonetwork*|*\ localmode*) localmode=yes;; esac
 
  # process parameters given on kernel command line
- for i in $CMDLINE; do
+ for arg in $CMDLINE; do
 
-  case "$i" in
-
+  case "$arg" in
+   debug) debug=yes;;
+   nonetwork|localmode) localmode=yes;;
+   
    # evalutate sata_nv options
    sata_nv.swnc=*)
-    value="$(echo $i | awk -F\= '{ print $2 }')"
+    value="$(echo $arg | awk -F\= '{ print $2 }')"
     echo "options sata_nv swnc=$value" > /etc/modprobe.d/sata_nv.conf
    ;;
 


### PR DESCRIPTION
`case "$CMDLINE" in *\ debug*) return 0 ;; esac` won't work when there is no preceding space (which there isn't if there is no other command before). Also, this is going to wrongfully parse all arguments which only START with `debug`, no matter what they end with.
