### PR TITLE
Auto increment IP and hostname on register.

### DIFF
--- a/linbo/linbo_cmd.sh
+++ b/linbo/linbo_cmd.sh
@@ -2095,6 +2095,48 @@ size(){
  return 0
 }
 
+#
+# Ermittelt den logisch naechsten Hostnamen, um die Rechneraufnahme zu
+# erleichtern
+#
+preregister() {
+	cd /tmp
+	interruptible rsync --progress -HaP "$1::linbo/workstations" "workstations.$$" ; RC="$?"
+	LASTWORKSTATION=$(cat /tmp/workstations.$$ | grep ^[a-z] | tail -n 1)
+
+	if [ "$LASTWORKSTATION" == "" ]; then
+		echo ",,," > /tmp/newregister
+		rm /tmp/workstations.$$
+		return 0
+	fi
+
+	LASTGROUP=$(echo $LASTWORKSTATION | cut -d ";" -f 3)
+	LASTROOM=$(echo $LASTWORKSTATION | cut -d ";" -f 1)
+	LASTHOST=$(echo $LASTWORKSTATION | cut -d ";" -f 2)
+	LASTIP=$(echo $LASTWORKSTATION | cut -d ";" -f 5)
+
+	# Naechste IP ermitteln
+	NEXTIP="$(echo -n $LASTIP | cut -d "." -f 1-3).$(($(echo $LASTIP | cut -d "." -f 4)+1))"
+
+	# Naechsten Hostnamen ermitteln
+	HOSTNAMECOUNTER=$(echo $LASTHOST | grep -Eo "[0-9]+$")
+	if [ ! "$HOSTNAMECOUNTER" == "" ]; then
+		NEXTCOUNT=$(expr $HOSTNAMECOUNTER + 1)
+		# Left fill with zeroes
+		while [ "${#NEXTCOUNT}" -lt "${#HOSTNAMECOUNTER}" ]; do
+			NEXTCOUNT=0$NEXTCOUNT
+		done
+
+		# Build new hostname
+		NEXTHOST=$(echo -n $LASTHOST | sed "s/${HOSTNAMECOUNTER}$//g")$NEXTCOUNT
+	else
+		NEXTHOST=$LASTHOST
+	fi
+	rm /tmp/workstations.$$
+	echo "$LASTROOM,$LASTGROUP,$NEXTHOST,$NEXTIP" > /tmp/newregister
+	return 0
+}
+
 version(){
  local versionfile="/etc/linbo-version"
  if [ -s "$versionfile" ]; then
@@ -2118,6 +2160,7 @@ case "$cmd" in
  start) start "$@" ;;
  partition_noformat) export NOFORMAT=1; partition "$@" ;;
  partition) partition "$@" ;;
+ preregister) preregister "$@";;
  initcache) initcache "$@" ;;
  initcache_format) echo "initcache_format gestartet."; export FORCE_FORMAT=1; initcache "$@" ;;
  mountcache) mountcache "$@" ;;

--- a/linbo_gui/linboGUIImpl.cc
+++ b/linbo_gui/linboGUIImpl.cc
@@ -1260,7 +1260,14 @@ linboGUIImpl::linboGUIImpl()
 			       config.get_consolefontcolorstderr(),
 			       Console );
   registerBox->setMainApp(this );
+  
+  //cout << "Preregister command";
+  command = LINBO_CMD("preregister");
+  saveappend( command, config.get_server() );
+  registerBox->setPreCommand( command );
 
+
+  //cout << "Register Command";
   command = LINBO_CMD("register");
   saveappend( command, config.get_server() );
   saveappend( command, QString("linbo") );

--- a/linbo_gui/linboRegisterBoxImpl.cc
+++ b/linbo_gui/linboRegisterBoxImpl.cc
@@ -61,7 +61,30 @@ void linboRegisterBoxImpl::setMainApp( QWidget* newMainApp ) {
 
 
 void linboRegisterBoxImpl::precmd() {
-  // nothing to do
+    // Die vorgeschlagenen Daten fuer die Rechneraufnahme lesen und anzeigen
+    QProcess* preprocess = new QProcess( this );
+    ifstream newdata;
+    QString registerData;
+    QStringList registerDataList;
+    char line[1024];
+    QStringList cmdargs( myPreCommand );
+
+    QString precommand = cmdargs.takeFirst();
+    preprocess->start(precommand, cmdargs);
+    preprocess->waitForFinished();
+
+    newdata.open("/tmp/newregister", ios::in);
+    if (newdata.is_open()) {
+        newdata.getline(line,1024,'\n');
+        registerData = QString::fromAscii( line, -1 ).stripWhiteSpace();
+        newdata.close();
+        registerDataList = registerData.split(',');
+
+        roomName->setText(registerDataList[0]);
+        clientGroup->setText(registerDataList[1]);
+        clientName->setText(registerDataList[2]);
+        ipAddress->setText(registerDataList[3]);
+    }
 }
 
 
@@ -129,6 +152,16 @@ void linboRegisterBoxImpl::setCommand(const QStringList& arglist)
 QStringList linboRegisterBoxImpl::getCommand()
 {
   return QStringList(myCommand); 
+}
+
+void linboRegisterBoxImpl::setPreCommand(const QStringList& arglist)
+{
+  myPreCommand = QStringList(arglist); // Create local copy
+}
+
+QStringList linboRegisterBoxImpl::getPreCommand()
+{
+  return QStringList(myPreCommand); 
 }
 
 void linboRegisterBoxImpl::readFromStdout()

--- a/linbo_gui/linboRegisterBoxImpl.hh
+++ b/linbo_gui/linboRegisterBoxImpl.hh
@@ -26,6 +26,7 @@ class linboRegisterBoxImpl : public QWidget, public Ui::linboRegisterBox, public
 private:
   QProcess* process;
   QStringList myCommand;
+  QStringList myPreCommand;
   linboProgressImpl *progwindow;
   linboGUIImpl *app;
   QString line;
@@ -41,6 +42,8 @@ public:
 		       const QString& new_consolefontcolorstderr,
 		       QTextEdit* newBrowser );
   virtual void setCommand(const QStringList& arglist);
+  virtual QStringList getPreCommand();
+  virtual void setPreCommand(const QStringList& arglist);
   virtual QStringList getCommand();
   // not needed here
   virtual void setMainApp( QWidget* newMainApp );


### PR DESCRIPTION
Zeigt als Vorschlag bei der Rechneraufnahme den zuletzt aufgenommenen Hostnamen + IP erhöht um eins an, falls möglich. Raum und Gruppe werden übernommen.

Beispiel:
Der zuletzt aufgenommene Rechner hieß a002-03 mit der IP 192.168.0.3, so wird nun im Registrierfeld a002-04 und 192.168.0.4 als IP angeboten.