### PR TITLE
update busybox to 1.22.1 stable

### DIFF
--- a/debian/md5sums.src
+++ b/debian/md5sums.src
@@ -1,5 +1,5 @@
 1400098dd8d9c65ee2e28b1f56a60469  backports-3.13.2-1.tar.xz
-8a5eb7f15d4077d18fa97bda7a4e5412  busybox-1.13.4.tar.bz2
+337d1a15ab1cb1d4ed423168b1eb7d7e  busybox-1.22.1.tar.bz2
 a3fb358d1adec589cd6bc8dedf68896c  chntpw-source-110511.zip
 458d7cc0c69646a2caaedec5c836cdcc  cloop_2.639-2.tar.gz
 59b23dd05ff70791cd6449effa7fc3b6  ctorrent-dnh3.3.2.tar.gz


### PR DESCRIPTION
support for xargs -I parameter (useful in postsync scripts) and other new features and bugfixes
