### PR TITLE
Fehlerhafte Zuweisungen gefixt

### DIFF
--- a/examples/win7-reactivate.bat
+++ b/examples/win7-reactivate.bat
@@ -7,21 +7,21 @@ rem Pfade und Dateinamen sind ggf. anzupassen.
 @echo off
 
 if exist "%PROGRAMFILES(X86)%" goto set32path
-VAMT="%PROGRAMFILES%\VAMT 2.0\Vamt.exe"
+set VAMT="%PROGRAMFILES%\VAMT 2.0\Vamt.exe"
 goto main
 
 :set32path
-VAMT="%PROGRAMFILES(X86)%\VAMT 2.0\Vamt.exe"
+set VAMT="%PROGRAMFILES(X86)%\VAMT 2.0\Vamt.exe"
 
 :main
 set WorkDir=C:\cil
 set InFile=%WorkDir%\schule.cil
 set OutFile=%WorkDir%\out.cil
 
-if not exist ""%VAMT%"" goto end
+if not exist %VAMT% goto end
 if not exist %InFile% goto end
 
-""%VAMT%"" /c /i %InFile% /o %OutFile%
+%VAMT% /c /i %InFile% /o %OutFile%
 
 rmdir /Q /S %WorkDir%
 


### PR DESCRIPTION
Die 'set' Anweisung fehlten, daher war VAMT nicht definiert und das Script konnte nicht durchlaufen.
Unnötige Anführungszeichen entfernt.