### PR TITLE
variable disk not working with mmc, not needed anyway

### DIFF
--- a/linbo/linbo_cmd.sh
+++ b/linbo/linbo_cmd.sh
@@ -1344,7 +1344,6 @@ start(){
  local KERNEL="${3#/}"
  local i
  local partition="$2"
- local disk="${partition%%[1-9]*}"
  local cachedev="$6"
  local startflag="/tmp/.start"
  touch "$startflag"


### PR DESCRIPTION
Hi Thomas,
kleine unwichtige Korrektur. Die Variable disk wird in einer mit mmc nicht kompatiblen Weise ermittelt und wird sowieso nicht (mehr) benötigt.
Gruß,
Frank