### PR TITLE
added battery monitor to linux_cmd

### DIFF
--- a/linbo/linbo_cmd.sh
+++ b/linbo/linbo_cmd.sh
@@ -2891,6 +2891,12 @@ mac(){
  echo "$mac"
 }
 
+# Find all available batteries, get their capacity and output capacity of first found battery
+battery()
+{
+ find /sys/class/power_supply/ -name 'BAT*' -exec cat {}/capacity \; | head -n 1
+}
+
 # register server user password variables...
 register(){
  local RC=1
@@ -3028,6 +3034,7 @@ case "$cmd" in
  cpu) cpu ;;
  memory) memory ;;
  mac) mac ;;
+ battery) battery ;;
  size) size "$@" ;;
  authenticate) authenticate "$@" ;;
  create) create "$@" ;;


### PR DESCRIPTION
Hallo Thomas,
für neu&start usw. ist es nützlich, im linbo_gui den Batteriezustand zu haben. Ich würde das gern einbauen. Dieser pull request fügt die Funktion zu linbo_cmd hinzu.
Gruß,
Frank
