### PR TITLE
Fix encoding of linbo_cmd.sh (broken umlauts etc.)

### DIFF
--- a/linbo/init.sh
+++ b/linbo/init.sh
@@ -211,23 +211,23 @@ copytocache(){
     mount "$cachedev" /cache || return 1
    fi
    if [ -s /start.conf ]; then
-    echo "Saving start.conf to cache."
+    echo "Speichere start.conf auf Cache."
     cp -a /start.conf /cache
    fi
    if [ -d /icons ]; then
-    echo "Saving icons to cache."
+    echo "Speichere Icons auf Cache."
     mkdir -p /cache/icons
     rsync /icons/* /cache/icons
    fi
    # save hostname for offline use
-   echo "Saving hostname $(hostname) to cache."
+   echo "Speichere Hostnamen $(hostname) auf Cache."
    hostname > /cache/hostname
    # deprecated
    #[ "$cachedev" = "$cache" ] && modify_cache /cache/start.conf
    umount /cache || umount -l /cache
    ;;
   *)
-   echo "No local cache partition found!"
+   echo "Keine lokale Cache-Partition gefunden!"
    return 1
    ;;
  esac
@@ -473,7 +473,7 @@ disable_auto(){
 set_autostart() {
  # return if autostart shall be suppressed generally
  if [ "$autostart" = "0" ]; then
-  echo "Disabling autostart generally."
+  echo "Deaktiviere autostart generell."
   # set all autostart parameters to no
   sed -e 's|^[Aa][Uu][Tt][Oo][Ss][Tt][Aa][Rr][Tt].*|Autostart = no|g' -i /start.conf
   return
@@ -493,7 +493,7 @@ set_autostart() {
   echo "$line" | grep -qi ^autostart || echo "$line" >> /start.conf.new
   # write autostart line for specific OS
   if [ "$found" = "1" ]; then
-   echo "Enabling autostart for os nr. $c."
+   echo "Aktiviere autostart für OS Nr. $c."
    echo "Autostart = yes" >> /start.conf.new
    found=0
   fi
@@ -504,7 +504,7 @@ set_autostart() {
 # disable start, sync and new buttons
 disable_buttons(){
  [ -s /start.conf ] || return
- echo "Disabling buttons."
+ echo "Deaktiviere Buttons."
  sed -e 's|^[Ss][Tt][Aa][Rr][Tt][Ee][Nn][Aa][Bb][Ll][Ee][Dd].*|StartEnabled = no|g
          s|^[Ss][Yy][Nn][Cc][Ee][Nn][Aa][Bb][Ll][Ee][Dd].*|SyncEnabled = no|g
          s|^[Nn][Ee][Ww][Ee][Nn][Aa][Bb][Ll][Ee][Dd].*|NewEnabled = no|g
@@ -513,9 +513,9 @@ disable_buttons(){
 
 network(){
  echo
- echo "Starting network configuration ..."
+ echo "Starte Netzwerkkonfiguration ..."
  if [ -n "$localmode" ]; then
-  echo "Localmode configured, skipping network configuration."
+  echo "Localmode konfiguriert, überspringe Netzwerkkonfiguration."
   copyfromcache "start.conf icons"
   do_housekeeping
   touch /tmp/linbo-network.done
@@ -523,12 +523,12 @@ network(){
  fi
  rm -f /tmp/linbo-network.done
  if [ -n "$ipaddr" ]; then
-  echo "Using static ip address $ipaddr."
+  echo "Benutze statische IP-Adresse $ipaddr."
   [ -n "$netmask" ] && nm="netmask $netmask" || nm=""
   ifconfig ${netdevice:-eth0} $ipaddr $nm &> /dev/null
  else
   # iterate over ethernet interfaces
-  echo "Requesting ip address per dhcp ..."
+  echo "Frage IP-Adresse per DHCP an ..."
   for i in /sys/class/net/eth*; do
    dev="${i##*/}"
    ifconfig "$dev" up &> /dev/null
@@ -536,6 +536,7 @@ network(){
    ethtool -s "$dev" wol g &> /dev/null
    # check if using vlan
    if [ -n "$vlanid" ]; then
+    echo "Benutze VLAN-ID $vlanid."
     vconfig add "$dev" "$vlanid" &> /dev/null
     dhcpdev="$dev.$vlanid"
     ip link set dev "$dhcpdev" up
@@ -561,13 +562,13 @@ network(){
  if [ -n "$server" ]; then
   export server
   echo "linbo_server='$server'" >> /tmp/dhcp.log
-  echo "Downloading configuration files from $server ..."
+  echo "Lade Konfigurationsdateien von $server ..."
   for i in "start.conf-$ipaddr" "start.conf"; do
    rsync -L "$server::linbo/$i" "start.conf" &> /dev/null && break
   done
   # set flag for working network connection
   if [ -s start.conf ]; then
-   echo "Network connection to $server successfully established."
+   echo "Netwerkverbindung zu $server erfolgreich hergestellt."
    echo > /tmp/network.ok
   fi
   # linbo update
@@ -617,20 +618,20 @@ network(){
  # sets flag if no default route
  route -n | grep -q ^0\.0\.0\.0 || echo > /tmp/.offline
  # start ssh server
- echo "Starting ssh server."
+ echo "Starte SSH-Server."
  /sbin/dropbear -s -g -E -p 2222 &> /dev/null
  # remove reboot flag, save windows activation
  do_housekeeping
  # done
  echo > /tmp/linbo-network.done
- echo "Done."
+ echo "Fertig."
  rm -f /outfifo
 }
 
 # HW Detection
 hwsetup(){
  rm -f /tmp/linbo-cache.done
- echo "## Hardware-Setup - Begin ##" >> /tmp/linbo.log
+ echo "## Hardware-Setup - Anfang ##" >> /tmp/linbo.log
 
  #
  # Udev starten
@@ -652,7 +653,7 @@ hwsetup(){
  export TERM_TYPE=pts
  
  dmesg >> /tmp/linbo.log
- echo "## Hardware-Setup - End ##" >> /tmp/linbo.log
+ echo "## Hardware-Setup - Ende ##" >> /tmp/linbo.log
 
  sleep 2
  echo > /tmp/linbo-cache.done 
@@ -661,20 +662,19 @@ hwsetup(){
 # Main
 #clear
 echo
-echo 'Welcome to'
-echo ' _        _   __     _   ____      _____'
-echo '| |      | | |  \   | | |  _ \    / ___ \'
-echo '| |      | | |   \  | | | | | |  / /   \ \'
-echo '| |      | | | |\ \ | | | |/ /  | |     | |'
-echo '| |      | | | | \ \| | | |\ \  | |     | |'
-echo '| |____  | | | |  \   | | |_| |  \ \___/ /'
-echo '|______| |_| |_|   \__| |____/    \_____/'
+echo 'Wilkommen zu'
+echo ' _      _____ _   _ ____   ____'
+echo '| |    |_   _| \ | |  _ \ / __ \'
+echo '| |      | | |  \| | |_) | |  | |'
+echo '| |      | | | . ` |  _ <| |  | |'
+echo '| |____ _| |_| |\  | |_) | |__| |'
+echo '|______|_____|_| \_|____/ \____/'
 echo
 
 # initial setup
 read_cmdline
 echo
-echo "Configuring hardware ..."
+echo "Konfiguriere Hardware ..."
 echo
 if [ -n "$quiet" ]; then
  init_setup &> /dev/null

--- a/linbo/linbo.sh
+++ b/linbo/linbo.sh
@@ -20,14 +20,14 @@ CMDLINE="$(cat /proc/cmdline)"
 case "$CMDLINE" in *\ debug*)
  for i in /tmp/linbo_gui.*.log; do
   if [ -s "$i" ]; then
-   echo "There is a log from an earlier start of linbo_gui in $i:"
+   echo "Es gibt ein Log von einem früheren Start von linbo_gui in $i::"
    cat "$i"
-   echo -n "Hit return to continue."
+   echo -n "Eingabetaste zum fortfahren drücken."
    read dummy
    rm -f "$i"
   fi
  done
- echo "Starting DEBUG Shell, leave with 'exit'."
+ echo "Starte DEBUG-Shell, verlassen mit 'exit'."
  ash >/dev/tty1 2>&1 < /dev/tty1
  ;;
 esac

--- a/linbo/linbo_cmd.sh
+++ b/linbo/linbo_cmd.sh
@@ -29,7 +29,7 @@ rm -f "$TMP"
 ps w | grep linbo_cmd | grep -v grep >"$TMP"
 if [ $(cat "$TMP" | wc -l) -gt 1 ]; then
 # echo "Possible Bug detected: linbo_cmd already running." >&2
- echo "Possible Bug detected: linbo_cmd already running." >> /tmp/linbo.log
+ echo "Möglicher Fehler erkannt: linbo_cmd läuft bereits." >> /tmp/linbo.log
  #cat "$TMP" >&2
  cat "$TMP" >> /tmp/linbo.log
 fi
@@ -117,7 +117,7 @@ var/log/ConsoleKit/history
 var/tmp/*'
 
 bailout(){
- echo "DEBUG: bailout() called, linbo_cmd=$PID, my_pid=$$" >&2
+ echo "DEBUG: bailout() aufgerufen, linbo_cmd=$PID, my_pid=$$" >&2
  echo ""
  # Kill all processes that have our PID as PPID.
  local processes=""
@@ -171,21 +171,21 @@ interruptible(){
 
 help(){
 echo "
- Invalid LINBO command: »$@«
+ Ungültiger LINBO-Befehl: »$@«
 
  Syntax: linbo_cmd command option1 option2 ...
 
- Examples:
+ Beispiele:
  start bootdev rootdev kernel initrd append
-               - boot OS
+               - Fahre Betriebssystem hoch
  syncr server  cachedev baseimage image bootdev rootdev kernel initrd
-               - sync cache from server AND partitions from cache
+               - Synchronisiere Cache vom Server, dann Partitionen vom Cache
  syncl cachedev baseimage image bootdev rootdev kernel initrd
-               - sync partitions from cache
+               - Synchronisiere Partitionen vom Cache
 
- Image types: 
- .cloop - full block device (partition) image, cloop-compressed
- .rsync - differential rsync batch, cloop-compressed
+ Image-Arten:
+ .cloop - Image vom kompletten Blockgerät (block device, z.B. Partition), CLOOP-komprimiert
+ .rsync - Differentielles RSYNC-Abbild, CLOOP-komprimiert
  " 1>&2
 }
 
@@ -390,13 +390,13 @@ mountpart(){
     break
    else
     [ "$i" = "5" ] && break
-    echo "Cloop-Device ist noch nicht verfuegbar, versuche erneut..."
+    echo "CLOOP-Device ist noch nicht verfügbar, versuche erneut..."
     wmsg=1
     sleep 2
    fi
   done
   if [ ! -b /dev/cloop0 ]; then
-   echo "Cloop-Device ist nicht bereit! Breche ab!"
+   echo "CLOOP-Device ist nicht bereit! Breche ab!"
    return 1
   else
    [ "$wmsg" = "1" ] && echo "...Ok! :-)"
@@ -408,10 +408,10 @@ mountpart(){
   RC="$?"
   [ "$RC" = "0" ] && break
   [ "$i" = "5" ] && break
-  echo "Partition $1 ist noch nicht verfuegbar, versuche erneut..."
+  echo "Partition $1 ist noch nicht verfügbar, versuche erneut..."
   sleep 2
  done
- [ "$RC" = "0" ] || { echo "Partition $1 ist nicht verfuegbar, wurde die Platte schon partitioniert?" 1>&2; return "$RC"; }
+ [ "$RC" = "0" ] || { echo "Partition $1 ist nicht verfügbar, wurde die Platte schon partitioniert?" 1>&2; return "$RC"; }
  case "$type" in
   *ntfs*)
    OPTS="$OPTS,recover,remove_hiberfile,user_xattr,inherit,acl"
@@ -480,10 +480,10 @@ format(){
    update "$(serverip)" "$cachedev"
    mk_boot
    if mountcache "$cachedev"; then
-    echo "Saving start.conf to cache."
+    echo "Speichere start.conf auf Cache."
     cp /start.conf /cache
     # save hostname for offline use
-    echo "Saving hostname $(hostname) to cache."
+    echo "Speichere Hostnamen $(hostname) auf Cache."
     hostname > /cache/hostname
    fi
   fi
@@ -534,7 +534,7 @@ mountcache(){
    mount $2 -t cifs -o user=linbo,pass="$PASSWD",nolock "$1" /cache 2>> /tmp/linbo.log
    RC="$?"
    if [ "$RC" != "0" ]; then
-    echo "Zugriff auf $1 als User \"linbo\" mit Authentifizierung klappt nicht."
+    echo "Zugriff auf $1 als Benutzer \"linbo\" mit Authentifizierung klappt nicht."
     mount $2 -t cifs -o nolock,guest,sec=none "$1" /cache 2>> /tmp/linbo.log
     RC="$?"
     if [ "$RC" != "0" ]; then
@@ -549,7 +549,7 @@ mountcache(){
 #     echo "Cache ist bereits gemountet."
 #     RC=0
 #    else
-     echo "Mounte Cachepartition $1 ..."
+     echo "Mounte Cache-Partition $1 ..."
      mountpart "$1" /cache $2 2>> /tmp/linbo.log ; RC="$?"
 #    fi
     if [ "$RC" != "0" ]; then
@@ -578,7 +578,7 @@ killalltorrents(){
  local WAIT=5
  # check for running torrents and kill them if any
  if [ -n "`ps w | grep ctorrent | grep -v grep`" ]; then
-  echo "Killing torrents ..."
+  echo "Stoppe Torrents ..."
   killall -9 ctorrent 2>/dev/null
   sleep "$WAIT"
   [ -n "`ps w | grep ctorrent | grep -v grep`" ] && sleep "$WAIT"
@@ -1169,7 +1169,7 @@ prepare_reboot(){
 prepare_grub(){
  local doneflag="/tmp/.prepare_grub"
  [ -e "$doneflag" ] && return 0
- echo "Aktualisiere Grub-Dateien im Cache:"
+ echo "Aktualisiere GRUB-Dateien im Cache:"
  local grubdir="$1"
  local grubenv="$2"
  local grubsharedir="$3"
@@ -1180,7 +1180,7 @@ prepare_grub(){
  echo "Ok!"
  # provide default grub.cfg with current append params on localmode
  if localmode; then
-  echo -n " * Schreibe Grub-Konfiguration in localmode ... "
+  echo -n " * Schreibe GRUB-Konfiguration in localmode ... "
   local kopts="$(kerneloptions)"
   [ -z "$kopts" ] && kopts="splash quiet localboot"
   sed -e "s|linux \$linbo_kernel .*|linux \$linbo_kernel $(kerneloptions) localboot|g" "$grubsharedir/grub.cfg" > "$grubdir/grub.cfg"
@@ -1195,7 +1195,7 @@ prepare_grub(){
  rsync /icons/linbo_wallpaper.png "$grubdir/linbo_wallpaper.png" || return 1
  echo "Ok!"
  # reset grubenv
- echo -n " * Schreibe Grub-Environment ... "
+ echo -n " * Schreibe GRUB-Environment ... "
  local RC="0"
  if [ -s "$grubenv" ]; then
   for i in reboot reboot_kernel reboot_initrd reboot_append; do
@@ -1242,7 +1242,7 @@ mk_boot(){
  fi
  # install grub in mbr/efi
  if [ ! -e "$doneflag" -a -n "$localcache" ]; then
-  echo -n "Installiere Grub in MBR/EFI von $grubdisk ... "
+  echo -n "Installiere GRUB in MBR/EFI von $grubdisk ... "
   grub-install "$grubdisk" 2>> /tmp/linbo.log || RC="1"
   if [ "$RC" = "0" ]; then
    touch "$doneflag"
@@ -1627,7 +1627,7 @@ mk_cloop(){
  esac
  # create torrent file
  if [ "$RC" = "0" ]; then
-  echo "Erstelle torrent Dateien ..." | tee -a /tmp/image.log
+  echo "Erstelle Torrent-Dateien ..." | tee -a /tmp/image.log
   touch "$3".complete
   local serverip="$(grep -i ^server /start.conf | awk -F\= '{ print $2 }' | awk '{ print $1 }')"
   ctorrent -t -u http://"$serverip":6969/announce -s "$3".torrent "$3" | tee -a /tmp/image.log
@@ -1676,14 +1676,14 @@ cp_cloop_ntfs(){
   return "$RC"
  fi
  # check if resizing is necessary
- echo "Pruefe ob Dateisystem vergroessert werden muss..." | tee -a /tmp/image.log
+ echo "Prüfe ob Dateisystem vergrößert werden muss..." | tee -a /tmp/image.log
  # save ntfs size infos in temp file
  ntfsresize -f -i "$targetdev" 2>> /tmp/image.log > /tmp/ntfs.info
  # get volume size in mb
  local volsizemb="$(grep "Current volume size" /tmp/ntfs.info | awk -F\( '{ print $2 }' | awk '{ print $1}')"
  # test if volsizemb is an integer value
  if ! isinteger "$volsizemb"; then
-  echo "Kann Dateisystemgroesse nicht bestimmen." | tee -a /tmp/image.log
+  echo "Kann Dateisystemgröße nicht bestimmen." | tee -a /tmp/image.log
   return 1
  fi  
  echo "Dateisystem: $volsizemb MB" | tee -a /tmp/image.log
@@ -1691,24 +1691,24 @@ cp_cloop_ntfs(){
  local devsizemb="$(grep "Current device size" /tmp/ntfs.info | awk -F\( '{ print $2 }' | awk '{ print $1}')"
  # test if devsizemb is an integer value
  if ! isinteger "$devsizemb"; then
-  echo "Kann Partitionsgroesse nicht bestimmen." | tee -a /tmp/image.log
+  echo "Kann Partitionsgröße nicht bestimmen." | tee -a /tmp/image.log
   return 1
  fi
  echo "Partition  : $devsizemb MB" | tee -a /tmp/image.log
  # test if partition is larger than filesystem and adjust filesystem size if necessary
  if [ $devsizemb -gt $volsizemb ]; then
-  echo "Dateisystem wird auf $devsizemb MB vergroessert." | tee -a /tmp/image.log
+  echo "Dateisystem wird auf $devsizemb MB vergrößert." | tee -a /tmp/image.log
   # get partition size in bytes
   local devsize="$(grep "Current device size" /tmp/ntfs.info | awk '{ print $4}')"
   if ! isinteger "$devsize"; then
-   echo "Kann Partitionsgroesse nicht bestimmen." | tee -a /tmp/image.log
+   echo "Kann Partitionsgröße nicht bestimmen." | tee -a /tmp/image.log
    return 1
   fi
   # increase the filesystem size
   ntfsresize -f -s "$devsize" "$targetdev" ; RC="$?"
-  [ "$RC" = "0" ] || echo "Vergroesserung von $targetdev ist fehlgeschlagen." | tee -a /tmp/image.log
+  [ "$RC" = "0" ] || echo "Vergrößerung von $targetdev ist fehlgeschlagen." | tee -a /tmp/image.log
  else
-  echo "Vergroesserung ist nicht notwendig." | tee -a /tmp/image.log
+  echo "Vergrößerung ist nicht notwendig." | tee -a /tmp/image.log
   RC=0
  fi # devsizemb gt volsizemb
  return "$RC"
@@ -1735,7 +1735,7 @@ cp_cloop(){
    local s2="$(get_partition_size $targetdev)"
    local block="$(($CLOOP_BLOCKSIZE / 1024))"
    if [ "$(($s1 - $block))" -gt "$s2" ] 2>/dev/null; then
-    echo "FEHLER: Cloop Image $imagefile (${s1}K) ist größer als Partition $targetdev (${s2}K)" >&2 | tee -a /tmp/image.log
+    echo "FEHLER: CLOOP-Image $imagefile (${s1}K) ist größer als Partition $targetdev (${s2}K)" >&2 | tee -a /tmp/image.log
     echo 'FEHLER: Das passt nicht!' >&2 | tee -a /tmp/image.log
     rmmod cloop >/dev/null 2>&1
     return 1
@@ -1776,7 +1776,7 @@ sync_cloop(){
    *.[Rr][Ss][Yy]*)
     # tschmitt: added logging parameter
     #interruptible rsync "$ROPTS" --fake-super --compress --partial --delete --log-file=/tmp/image.log --log-file-format="" --read-batch="$1" /mnt >"$TMP" 2>&1 ; RC="$?"
-    echo "Synchronisation laeuft ... bitte warten ..."
+    echo "Synchronisation läuft ... bitte warten ..."
     #interruptible rsync "$ROPTS" --compress --delete --log-file=/tmp/image.log --log-file-format="" --read-batch="$1" /mnt >"$TMP" 2>&1 ; RC="$?"
     interruptible rsync "$ROPTS" --compress --delete --log-file=/tmp/image.log --log-file-format="" --read-batch="$1" /mnt 2>&1 ; RC="$?"
     if [ "$RC" != "0" ]; then
@@ -1801,7 +1801,7 @@ sync_cloop(){
       #[ "$(fstype "$2")" = "vfat" ] && ROPTS="$ROPTS --inplace"
       # tschmitt: added logging parameter
       #interruptible rsync "$ROPTS" --fake-super --partial --exclude="/.linbo" --exclude-from="/tmp/rsync.exclude" --delete --delete-excluded --log-file=/tmp/image.log --log-file-format="" /cloop/ /mnt >"$TMP" 2>&1 ; RC="$?"
-      echo "Synchronisation laeuft ... bitte warten ..."
+      echo "Synchronisation läuft ... bitte warten ..."
       interruptible rsync "$ROPTS" --exclude="/.linbo" --exclude-from="/tmp/rsync.exclude" --delete --delete-excluded --log-file=/tmp/image.log --log-file-format="" /cloop/ /mnt 2>&1 ; RC="$?"
       umount /cloop
       if [ "$RC" != "0" ]; then
@@ -2057,7 +2057,7 @@ syncl(){
  local bootdir
  # don't sync in that case
  if [ "$1" = "$rootdev" ]; then
-  echo "Ueberspringe lokale Synchronisation. Image $2 wird direkt aus Cache gestartet."
+  echo "Überspringe lokale Synchronisation. Image $2 wird direkt aus Cache gestartet."
   return 0
  fi
  echo -n "syncl " ; printargs "$@"
@@ -2146,10 +2146,10 @@ syncl(){
     fi
     # restore win7 bcd
     if [ -s "$bcd_backup_efi" ]; then
-     echo "Restauriere die Windows-Bootkonfiguration fuer Gruppe $group und Partition $partname."
+     echo "Restauriere die Windows-Bootkonfiguration für Gruppe $group und Partition $partname."
      cp -f "$bcd_backup_efi" "$bootdir"/BCD
     elif [ -s "$bcd_backup" ]; then
-     echo "Restauriere die Windows-Bootkonfiguration fuer Gruppe $group."
+     echo "Restauriere die Windows-Bootkonfiguration für Gruppe $group."
      cp -f "$bcd_backup" "$bootdir"/BCD
     fi
     # restore win7 mbr flag
@@ -2489,7 +2489,7 @@ download_if_newer(){
      # remove old image and torrents before download starts
      rm -f "$2" "$2".torrent.bf
      download_torrent "$2" ; RC="$?"
-     [ "$RC" = "0" ] ||  echo "Download von $2 per torrent fehlgeschlagen!" >&2
+     [ "$RC" = "0" ] ||  echo "Download von $2 per Torrent fehlgeschlagen!" >&2
     ;;
     multicast)
      if [ -s /multicast.list ]; then
@@ -2509,9 +2509,9 @@ download_if_newer(){
    esac
    # download per rsync also as a fallback if other download types failed
    if [ "$RC" != "0" -o "$DLTYPE" = "rsync" ]; then
-    [ "$RC" = "0" ] || echo "Versuche Download per rsync." >&2
+    [ "$RC" = "0" ] || echo "Versuche Download per RSYNC." >&2
     download_all "$1" "$2" ; RC="$?"
-    [ "$RC" = "0" ] || echo "Download von $2 per rsync fehlgeschlagen!" >&2
+    [ "$RC" = "0" ] || echo "Download von $2 per RSYNC fehlgeschlagen!" >&2
    fi
    # download supplemental files and set complete flag if image download was successful
    if [ "$RC" = "0" ]; then
@@ -2587,7 +2587,7 @@ upload(){
   for ext in info reg desc torrent; do
    [ -s "${5}.${ext}" ] && FILES="$FILES ${5}.${ext}"
   done
-  echo "Uploade $FILES auf $1..." | tee -a /tmp/linbo.log
+  echo "Lade $FILES auf $1 hoch ..." | tee -a /tmp/linbo.log
   for file in $FILES; do
    interruptible rsync --log-file=/tmp/rsync.log --progress -Ha $RSYNC_PERMISSIONS --partial "$file" "$2@$1::linbo-upload/$file"
    # because return code is always 0 this is necessary
@@ -2652,7 +2652,7 @@ update(){
  local force="$3"
 
  if [ -e "$doneflag" -a -z "$force" ]; then
-  echo "LINBO-Update wurde schon ausgefuehrt!"
+  echo "LINBO-Update wurde schon ausgeführt!"
   return 0
  else
   rm -f "$doneflag"
@@ -2682,7 +2682,7 @@ update(){
  [ -s start.conf ] || cp /start.conf .
 
  # get current linbo kernel/initrd and group specific and local grub configs from server
- echo "Aktualisiere LINBO-Kernel und Grub-Konfiguration."
+ echo "Aktualisiere LINBO-Kernel und GRUB-Konfiguration."
  for i in "$kernel" "$kernelfs" boot/grub/ipxe.lkrn "boot/grub/$group.cfg" "boot/grub/spool/$myname.$group.grub.cfg"; do
   # collect md5 before download
   if [ "$i" = "boot/grub/$group.cfg" ]; then
@@ -2711,12 +2711,12 @@ update(){
  mv "$group.cfg" "$grubdir/custom.cfg" || RC=1
  mv "$myname.$group.grub.cfg" "$grubdir/grub.cfg" || RC=1
  if [ "$RC" = "1" ]; then
-  echo "Fehler beim Schreiben der Grub-Konfigurationsdateien!" >&2
+  echo "Fehler beim Schreiben der GRUB-Konfigurationsdateien!" >&2
   return 1
  fi
 
  # keep grub themes also updated
- echo -n "Aktualisiere Grub-Themes ... "
+ echo -n "Aktualisiere GRUB-Themes ... "
  themesdir="/boot/grub/themes"
  mkdir -p "/cache$themesdir"
  rsync -a --delete "${server}::linbo${themesdir}/" "/cache${themesdir}/" || RC=1
@@ -2743,7 +2743,7 @@ update(){
 
   # remove for old legacy grub stuff
   if [ -e "$grubdir/stage1" -o -e "$grubdir/menu.lst" ]; then
-   echo "Entferne Grub legacy, Reboot wird notwendig."
+   echo "Entferne GRUB legacy, Reboot wird notwendig."
    rm -f "$grubdir"/*stage* "$grubdir"/menu.lst gpxe.krn
    if [ -e /cache/update.log ]; then
     cat /cache/update.log >> /tmp/linbo.log
@@ -2884,12 +2884,12 @@ ready(){
 #  echo -n "."
   count=`expr $count + 1`
   if [ "$count" -gt 120 ]; then
-   echo "Timeout, LINBO not ready. :-(" >&2
+   echo "Zeitüberschreitung, LINBO noch nicht fertig. :-(" >&2
    return 1
   fi
  done
- localmode || echo "Network OK."
- echo "Local Disk(s) OK."
+ localmode || echo "Netzwerk OK."
+ echo "Lokale Festplatte(n) OK."
  return 0
 }
 

--- a/linbo/linbo_cmd.sh
+++ b/linbo/linbo_cmd.sh
@@ -25,7 +25,7 @@ TMP="/tmp/linbo_cmd.$$.tmp"
 rm -f "$TMP"
 
 # Nur zum Debuggen
-# echo "»linbo_cmd«" "»$@«"
+# echo "Â»linbo_cmdÂ«" "Â»$@Â«"
 ps w | grep linbo_cmd | grep -v grep >"$TMP"
 if [ $(cat "$TMP" | wc -l) -gt 1 ]; then
 # echo "Possible Bug detected: linbo_cmd already running." >&2
@@ -42,7 +42,7 @@ printargs(){
  local arg
  local count=1
  for arg in "$@"; do
-  echo -n "$((count++)):»$arg« "
+  echo -n "$((count++)):Â»$argÂ« "
  done
  echo ""
 }
@@ -171,7 +171,7 @@ interruptible(){
 
 help(){
 echo "
- Invalid LINBO command: »$@«
+ Invalid LINBO command: Â»$@Â«
 
  Syntax: linbo_cmd command option1 option2 ...
 
@@ -567,7 +567,7 @@ mountcache(){
    fi
    ;;
    *) # Yet unknown
-   echo "Unbekannte Quelle für LINBO-Cache: $1" >&2
+   echo "Unbekannte Quelle fÃ¼r LINBO-Cache: $1" >&2
    ;;
   esac
  [ "$RC" = "0" ] || echo "Kann $1 nicht als /cache einbinden." >&2
@@ -1540,9 +1540,9 @@ mk_cloop(){
  case "$1" in
   partition) # full partition dump
    if mountpart "$2" /mnt -w 2>> /tmp/linbo.log; then
-    echo "Bereite Partition $2 (Größe=${size}K) für Komprimierung vor..." | tee -a /tmp/image.log
+    echo "Bereite Partition $2 (GrÃ¶ÃŸe=${size}K) fÃ¼r Komprimierung vor..." | tee -a /tmp/image.log
     prepare_fs /mnt "$2" | tee -a /tmp/image.log
-    echo "Leeren Platz auffüllen mit 0en..." | tee -a /tmp/image.log
+    echo "Leeren Platz auffÃ¼llen mit 0en..." | tee -a /tmp/image.log
     # Create nulled files of size 1GB, should work on any FS.
     local count=0
     while true; do
@@ -1615,7 +1615,7 @@ mk_cloop(){
      fi
     else
      echo "Image $4 kann nicht eingebunden werden," | tee -a /tmp/image.log
-     echo "ist aber für die differentielle Sicherung notwendig." | tee -a /tmp/image.log
+     echo "ist aber fÃ¼r die differentielle Sicherung notwendig." | tee -a /tmp/image.log
      RC="$?"
     fi
     rmmod cloop >/dev/null 2>&1
@@ -1646,7 +1646,7 @@ check_status(){
  mountpart "$1" /mnt -r 2>> /tmp/linbo.log || return $?
  [ -s /mnt/.linbo ] && case "$(cat /mnt/.linbo 2>/dev/null)" in *$base*) RC=0 ;; esac
  umount /mnt || umount -l /mnt
-# [ "$RC" = "0" ] && echo "Enthält schon eine Version von $2."
+# [ "$RC" = "0" ] && echo "EnthÃ¤lt schon eine Version von $2."
  return "$RC"
 }
 
@@ -1735,7 +1735,7 @@ cp_cloop(){
    local s2="$(get_partition_size $targetdev)"
    local block="$(($CLOOP_BLOCKSIZE / 1024))"
    if [ "$(($s1 - $block))" -gt "$s2" ] 2>/dev/null; then
-    echo "FEHLER: Cloop Image $imagefile (${s1}K) ist größer als Partition $targetdev (${s2}K)" >&2 | tee -a /tmp/image.log
+    echo "FEHLER: Cloop Image $imagefile (${s1}K) ist grÃ¶ÃŸer als Partition $targetdev (${s2}K)" >&2 | tee -a /tmp/image.log
     echo 'FEHLER: Das passt nicht!' >&2 | tee -a /tmp/image.log
     rmmod cloop >/dev/null 2>&1
     return 1
@@ -1982,7 +1982,7 @@ restore_winact(){
  [ -s  /mnt/.linbo ] && local image="$(cat /mnt/.linbo)"
  # if an image is not yet created do nothing
  if [ -z "$image" ]; then
-  echo "Überspringe Reaktivierung, System ist unsynchronisiert."
+  echo "Ãœberspringe Reaktivierung, System ist unsynchronisiert."
   return
  fi
  local archive
@@ -2035,7 +2035,7 @@ restore_winact(){
  fi
  # no data available
  if [ ! -s "/cache/$archive" -o ! -s "/cache/$image.winact.cmd" ]; then
-  echo "Überspringe Reaktivierung, keine Daten."
+  echo "Ãœberspringe Reaktivierung, keine Daten."
   return
  fi
  echo "Stelle Windows-Aktivierungstokens wieder her."
@@ -2361,7 +2361,7 @@ torrent_watchdog(){
   echo "Image $image erfolgreich heruntergeladen." | tee -a /tmp/image.log
  else
   ps w | grep -v grep | grep -q ctorrent && killall -9 ctorrent
-  echo "Download von $image wegen Zeitüberschreitung abgebrochen." >&2 | tee -a /tmp/image.log
+  echo "Download von $image wegen ZeitÃ¼berschreitung abgebrochen." >&2 | tee -a /tmp/image.log
  fi
  return "$RC"
 }
@@ -2387,7 +2387,7 @@ download_torrent(){
  local OPTS="-e 100000 -I $ip -M $MAX_INITIATE -z $SLICE_SIZE"
  [ $MAX_UPLOAD_RATE -gt 0 ] && OPTS="$OPTS -U $MAX_UPLOAD_RATE"
  echo "Torrent-Optionen: $OPTS" >> /tmp/image.log
- echo "Starte Torrent-Dienst für $image." | tee -a /tmp/image.log
+ echo "Starte Torrent-Dienst fÃ¼r $image." | tee -a /tmp/image.log
  local logfile=/tmp/"$image".log
  if [ ! -e "$complete" ]; then
   rm -f "$image" "$torrent".bf
@@ -2444,10 +2444,10 @@ download_if_newer(){
    local fs2="$(get_filesize "$2")"
    if [ -n "$ts1" -a -n "$ts2" -a "$ts1" -gt "$ts2" ] >/dev/null 2>&1; then
     DOWNLOAD_ALL="true"
-    echo "Server enthält eine neuere ($ts2) Version von $2 ($ts1)."
+    echo "Server enthÃ¤lt eine neuere ($ts2) Version von $2 ($ts1)."
    elif  [ -n "$fs1" -a -n "$fs2" -a ! "$fs1" -eq "$fs2" ] >/dev/null 2>&1; then
     DOWNLOAD_ALL="true"
-    echo "Dateigröße von $2 ($fs1) im Cache ($fs2) stimmt nicht."
+    echo "DateigrÃ¶ÃŸe von $2 ($fs1) im Cache ($fs2) stimmt nicht."
    fi
    rm -f "$2".info.old
   else
@@ -2497,11 +2497,11 @@ download_if_newer(){
       if [ -n "$MPORT" ]; then
        download_multicast "$1" "$MPORT" "$2" ; RC="$?"
       else
-       echo "Konnte Multicast-Port nicht bestimmen, kein Multicast-Download möglich." >&2
+       echo "Konnte Multicast-Port nicht bestimmen, kein Multicast-Download mÃ¶glich." >&2
        RC=1
       fi
      else
-      echo "Datei multicast.list nicht gefunden, kein Multicast-Download möglich." >&2
+      echo "Datei multicast.list nicht gefunden, kein Multicast-Download mÃ¶glich." >&2
       RC=1
      fi
      [ "$RC" = "0" ] || echo "Download von $2 per multicast fehlgeschlagen!" >&2
@@ -2525,7 +2525,7 @@ download_if_newer(){
    [ "$RC" = "0" ] || echo "Download von $2 fehlgeschlagen!" >&2
   fi
  else # download nothing, no newer file on server
-  echo "Keine neuere Version vorhanden, überspringe $2."
+  echo "Keine neuere Version vorhanden, Ã¼berspringe $2."
  fi
  return "$RC"
 }
@@ -2572,7 +2572,7 @@ upload(){
  local ext
  if remote_cache "$4"; then
   echo "Cache $4 ist nicht lokal, die Datei $5 befindet sich" | tee -a /tmp/linbo.log
-  echo "höchstwahrscheinlich bereits auf dem Server, daher kein Upload." | tee -a /tmp/linbo.log
+  echo "hÃ¶chstwahrscheinlich bereits auf dem Server, daher kein Upload." | tee -a /tmp/linbo.log
   sendlog
   return 1
  fi
@@ -2624,7 +2624,7 @@ upload(){
 syncr(){
  echo -n "syncr " ; printargs "$@"
  if remote_cache "$2"; then
-  echo "Cache $2 ist nicht lokal, überspringe Aktualisierung der Images."
+  echo "Cache $2 ist nicht lokal, Ã¼berspringe Aktualisierung der Images."
  else
   mountcache "$2" || return "$?"
   cd /cache
@@ -2813,7 +2813,7 @@ initcache(){
    fi
   done
   if [ "$found" = "0" ]; then
-   echo "Entferne nicht mehr benötigte Imagedatei $i." | tee -a /tmp/image.log
+   echo "Entferne nicht mehr benÃ¶tigte Imagedatei $i." | tee -a /tmp/image.log
    rm -f "$i" "$i".*
   fi
  done
@@ -2919,12 +2919,12 @@ register(){
  # Plausibility check
  if echo "$client" | grep -qi '[^a-z0-9-]'; then
   echo "Falscher Rechnername: '$client'," >&2
-  echo "Rechnernamen dürfen nur Buchstaben [a-z0-9-] enthalten." >&2
+  echo "Rechnernamen dÃ¼rfen nur Buchstaben [a-z0-9-] enthalten." >&2
   return 1
  fi
  if echo "$group" | grep -qi '[^a-z0-9_]'; then
   echo "Falscher Gruppenname: '$group'," >&2
-  echo "Rechnergruppen dürfen nur Buchstaben [a-z0-9_] enthalten." >&2
+  echo "Rechnergruppen dÃ¼rfen nur Buchstaben [a-z0-9_] enthalten." >&2
   return 1
  fi
  cd /tmp

--- a/linbo/linbo_wrapper.sh
+++ b/linbo/linbo_wrapper.sh
@@ -13,7 +13,7 @@ ARGS="$@"
 
 # check for concurrent processes
 if ps w | grep linbo_cmd | grep -v grep; then
- echo "There is already a linbo_cmd process running. Aborting!"
+ echo "Es läuft bereits ein linbo_cmd-Prozess. Breche ab!"
  exit 1
 fi
 
@@ -79,7 +79,7 @@ get_images(){
 get_os(){
  # check for valid start.conf
  if ! grep -qi ^"\[os\]" /start.conf; then
-  echo "Error! No os definitions found in start.conf!"
+  echo "Error! Keine OS-Definition in start.conf gefunden!"
   return 1
  fi
  local line=""
@@ -144,11 +144,11 @@ stripvalue(){
 get_partitions() {
  # check for valid start.conf
  if ! grep -qi ^"\[partition\]" /start.conf; then
-  echo "Error! No partition definitions found in start.conf!"
+  echo "Error! Keine Partitions-Definition in start.conf gefunden!"
   return 1
  fi
  if ! grep -qi ^"\[os\]" /start.conf; then
-  echo "Error! No os definitions found in start.conf!"
+  echo "Error! Keine OS-Definition in start.conf gefunden!"
   return 1
  fi
  # define local variables
@@ -202,22 +202,22 @@ format_partition(){
   [Ee][Xx][Tt][234]) fcmd="mkfs.$fstype $dev" ;;
   [Nn][Tt][Ff][Ss]) fcmd="mkfs.ntfs -Q $dev" ;;
   [Vv][Ff][Aa][Tt]) fcmd="mkdosfs -F 32 $dev" ;;
-  *) echo "Unknown filesystem: $fstype!"
+  *) echo "Unbekanntes Dateisystem: $fstype!"
      return 1 ;;
  esac
  if [ -n "$fcmd" ]; then
   # test if device is present after partitioning, if not wait 3 secs
   if [ ! -b "$dev" ]; then
-   echo "Partition $dev is not yet ready ... waiting 3 seconds ..."
+   echo "Partition $dev ist noch nicht bereit ... Warte 3 Sekunden ..."
    sleep 3
   fi
   # test again, abort if device is not there
   if [ ! -b "$dev" ]; then
-   echo "Partition $dev does not exist ... aborting!"
+   echo "Partition $dev existiert nicht ... Breche ab!"
    return 1
   fi
   if ! $fcmd; then
-   echo "Error on formatting $dev ... aborting!"
+   echo "Fehler beim Formatieren von $dev ... Breche ab!"
    return 1
   fi
  fi
@@ -248,39 +248,38 @@ create_desc(){
 # print help
 help(){
  echo
- echo "Usage: `basename $0` <command1 command2 ...>"
+ echo "Benutzung: `basename $0` <command1 command2 ...>"
  echo
- echo "`basename $0` allows the use of linbo_cmd easyly on the commandline."
- echo "It reads the start.conf file and builds the commands accordingly."
+ echo "`basename $0` erlaubt die einfache Benutzung von linbo_cmd auf der Kommandozeile."
+ echo "Es liest die start.conf und setzt die entsprechenden Befehle zusammen."
  echo
- echo "Allowed commands are:"
+ echo "Verfügbare Befehle sind:"
  echo
- echo "partition                : Writes the partition table."
- echo "format                   : Writes the partition table and formats all"
- echo "                           partitions."
- echo "format:<#>               : Writes the partition table and formats only"
- echo "                           partition nr <#>."
- echo "initcache:<dltype>       : Updates local cache. <dltype> is one of"
- echo "                           rsync|multicast|torrent."
- echo "                           If dltype is not specified it is read from"
- echo "                           start.conf."
- echo "sync:<#>                 : Syncs the operating system on position nr <#>."
- echo "start:<#>                : Starts the operating system on pos. nr <#>."
- echo "create_cloop:<#>:<\"msg\"> : Creates a cloop image from operating system nr <#>."
- echo "create_rsync:<#>:<\"msg\"> : Creates a rsync image from operating system nr <#>."
- echo "upload_cloop:<#>         : Uploads the cloop image from operating system nr <#>."
- echo "upload_rsync:<#>         : Uploads the rsync image from operating system nr <#>."
- echo "update                   : Update the kernel,initrd and install grub to MBR"
- echo "reboot                   : Reboots the client."
- echo "halt                     : Shuts the client down."
- echo "help                     : Shows this page."
+ echo "partition                : Schreibe die Partitionstabelle."
+ echo "format                   : Schreibt die Partitionstabelle und formatiert"
+ echo "                           alle Partitionen."
+ echo "format:<#>               : Schreibt die Partitionstabelle und formatiert"
+ echo "                           nur Partition Nr. <#>."
+ echo "initcache:<dltype>       : Aktualisiert den lokalen Cache. <dltype> ist"
+ echo "                           rsync, multicast oder torrent."
+ echo "                           Wenn <dltype> nicht angegeben ist wird er aus der"
+ echo "                           start.conf gelesen."
+ echo "sync:<#>                 : Synchronisiert das Betriebssystem auf Position Nr. <#>."
+ echo "start:<#>                : Startet das Betriebssystem auf Position Nr. <#>."
+ echo "create_cloop:<#>:<\"msg\"> : Erstellt ein CLOOP-image von Betriebssystem Nr. <#>."
+ echo "create_rsync:<#>:<\"msg\"> : Erstellt ein RSYNC-image von Betriebssystem Nr. <#>."
+ echo "upload_cloop:<#>         : Lädt das CLOOP-image von Betriebssystem Nr. <#> hoch."
+ echo "upload_rsync:<#>         : Lädt das RSYNC-image von Betriebssystem Nr. <#> hoch."
+ echo "update                   : Aktualisiere LINBOs Kernel/RAM-Disk und installiere GRUB."
+ echo "reboot                   : Client neustarten."
+ echo "halt                     : Client herunterfahren."
+ echo "help                     : Zeigt diese Hilfe."
  echo
- echo "<\"msg\"> is an optional image comment."
- echo "The position numbers are related to the position in start.conf."
- echo "The commands are processed in the commandline given order."
- echo "The upload commands expect a file /tmp/rsyncd.secrets with rsync credentials"
- echo "in the form:"
- echo "user:password"
+ echo "<\"msg\"> ist ein optionaler Image-Kommentar."
+ echo "Die Positions-Nummern beziehen sich auf die Position in der start.conf."
+ echo "Die Befehle werden in der Reihenfolge ausgeführt, in der sie übergeben werden."
+ echo "Der upload-Befehl erwartet eine Datei /tmp/rsyncd.secrets mit RSYNC-Anmeldedaten"
+ echo "in der Form: <Benutzername>:<Passwort>"
  echo
  exit
 }
@@ -296,10 +295,10 @@ while [ "$#" -gt "0" ]; do
  customimage=`echo "$1" | awk -F\: '{ print $4 }'`
 
  # do not print linbo password
- echo "command      : $cmd"
- [ -n "$param" -a "$cmd" != "linbo" ] && echo "parameter    : $param"
- [ -n "$msg" ] && echo "comment      : $msg"
- [ -n "$customimage" ] && echo "custom image : $customimage"
+ echo "Befehl      : $cmd"
+ [ -n "$param" -a "$cmd" != "linbo" ] && echo "Parameter    : $param"
+ [ -n "$msg" ] && echo "Kommentar      : $msg"
+ [ -n "$customimage" ] && echo "Benutzerdefiniertes Image : $customimage"
 
  case "$cmd" in
 
@@ -339,35 +338,35 @@ while [ "$#" -gt "0" ]; do
    if [ -n "$server" -a -n "$cachedev" -a -n "$images" ]; then
     linbo_cmd initcache $server $cachedev $downloadtype $images
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Initcache command was: linbo_cmd initcache $server $cachedev $downloadtype $images"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Initcache-Befehl war: linbo_cmd initcache $server $cachedev $downloadtype $images"
    fi
   ;;
 
   create_cloop)
    osnr="$param"
    if ! isinteger "$osnr"; then
-    echo "$osnr is not an integer!"
+    echo "$osnr ist keine Zahl!"
     shift
     continue
    fi
    get_os
-   echo "Creating $baseimage from $osname ..."
+   echo "Erstelle $baseimage von $osname ..."
    [ -z "$cachedev" ] && get_cachedev
    [ -n "$customimage" ] && baseimage="$customimage"
    if [ -n "$cachedev" -a -n "$baseimage" -a -n "$bootdev" -a -n "$rootdev" -a -n "$kernel" ]; then
     create_desc "$baseimage"
     linbo_cmd create "$cachedev" "$baseimage" "" "$bootdev" "$rootdev" "$kernel" "$initrd"
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Create command was: linbo_cmd create $cachedev $baseimage $bootdev $rootdev $kernel $initrd"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Create-Befehl war: linbo_cmd create $cachedev $baseimage $bootdev $rootdev $kernel $initrd"
    fi
   ;;
 
   upload_cloop)
    osnr="$param"
    if ! isinteger "$osnr"; then
-    echo "$osnr is not an integer!"
+    echo "$osnr ist keine Zahl!"
     shift
     continue
    fi
@@ -375,34 +374,34 @@ while [ "$#" -gt "0" ]; do
    get_passwd
    [ -z "$server" ] && get_server
    [ -z "$server" ] && return 1
-   echo "Uploading $baseimage to $server ..."
+   echo "Lade $baseimage zu $server hoch ..."
    [ -z "$cachedev" ] && get_cachedev
    [ -n "$customimage" ] && baseimage="$customimage"
    if [ -n "$server" -a -n "$user" -a -n "$password" -a -n "$cachedev" -a -n "$baseimage" ]; then
     linbo_cmd upload "$server" "$user" "$password" "$cachedev" "$baseimage"
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Upload command was: linbo_cmd upload $server $user $password $cachedev $baseimage"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Upload-Befehl war: linbo_cmd upload $server $user $password $cachedev $baseimage"
    fi
   ;;
 
   create_rsync)
    osnr="$param"
    if ! isinteger "$osnr"; then
-    echo "$osnr is not an integer!"
+    echo "$osnr ist keine Zahl!"
     shift
     continue
    fi
    get_os
-   echo "Creating $image from $osname ..."
+   echo "Erstelle $image von $osname ..."
    [ -z "$cachedev" ] && get_cachedev
    [ -n "$customimage" ] && image="$customimage"
    if [ -n "$cachedev" -a -n "$image" -a -n "$baseimage" -a -n "$bootdev" -a -n "$rootdev" -a -n "$kernel" ]; then
     create_desc "$image"
     linbo_cmd create "$cachedev" "$image" "$baseimage" "$bootdev" "$rootdev" "$kernel" "$initrd"
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Create command was: linbo_cmd create $cachedev $image $bootdev $rootdev $kernel $initrd"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Create-Befehl war: linbo_cmd create $cachedev $image $bootdev $rootdev $kernel $initrd"
    fi
   ;;
 
@@ -451,31 +450,31 @@ while [ "$#" -gt "0" ]; do
   start)
    osnr="$param"
    if ! isinteger "$osnr"; then
-    echo "$osnr is not an integer!"
+    echo "$osnr ist keine Zahl!"
     shift
     continue
    fi
    get_os
-   echo "Starting $osname ..."
+   echo "Starte $osname ..."
    [ -z "$cachedev" ] && get_cachedev
    if [ -n "$bootdev" -a -n "$rootdev" -a -n "$kernel" -a -n "$cachedev" ]; then
     linbo_cmd start "$bootdev" "$rootdev" "$kernel" "$initrd" "$append" "$cachedev"
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Start command was: linbo_cmd start $bootdev $rootdev $kernel $initrd $append $cachedev"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Start-Befehl war: linbo_cmd start $bootdev $rootdev $kernel $initrd $append $cachedev"
     exit 1
    fi
   ;;
 
   update)
-   echo "Updating kernel,initrd and installing grub to MBR ..."
+   echo "Aktualisiere LINBOs Kernel/RAM-Disk und installiere GRUB ..."
    [ -z "$server" ] && get_server
    [ -z "$cachedev" ] && get_cachedev
    if [ -n "$server" -a -n "$cachedev" ]; then
     linbo_cmd update "$server" "$cachedev"
    else
-    echo "Failed! One or more necessary parameters are missing!"
-    echo "Update command was: linbo_cmd update $server $cachedev"
+    echo "Fehlgeschlagen! Einer oder mehrere benötigte Parameter fehlen!"
+    echo "Update-Befehl war: linbo_cmd update $server $cachedev"
     exit 1
    fi
   ;;
@@ -491,4 +490,3 @@ while [ "$#" -gt "0" ]; do
 done
 
 exit 0
-


### PR DESCRIPTION
Hallo Thomas,
die Datei war noch mit ISO-8859 kodiert, weshalb innerhalb von LINBO immer die Sonderzeichen verstümmelt waren.
Gruß,
Christian