### PR TITLE
create download links start.conf-... on the fly and remove them

### DIFF
--- a/files/lmn6/usr/share/linuxmuster-linbo/rsync-post-download.sh
+++ b/files/lmn6/usr/share/linuxmuster-linbo/rsync-post-download.sh
@@ -46,6 +46,9 @@ fi
 # recognize download request of local grub.cfg
 stringinstring ".grub.cfg" "$FILE" && EXT="grub-local"
 
+# recognize download request of start.conf-ip
+[[ ${FILE##$RSYNC_MODULE_PATH/} =~ start\.conf-[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]] && EXT="start.conf.gruppe"
+
 case $EXT in
 
  # remove linbocmd file after download
@@ -167,6 +170,12 @@ case $EXT in
    echo "Removing $FILE."
    rm -f "$FILE"
   fi
+ ;;
+
+ # remove download link start.conf-ip
+ start.conf.gruppe)
+  echo "remove link to $FILE"
+  [[ -L $FILE ]] && rm -f "$FILE"
  ;;
 
  *) ;;

--- a/files/lmn6/usr/share/linuxmuster-linbo/rsync-pre-download.sh
+++ b/files/lmn6/usr/share/linuxmuster-linbo/rsync-pre-download.sh
@@ -30,6 +30,9 @@ stringinstring "winact.tar.gz.upload" "$FILE" && EXT="winact-upload"
 # recognize download request of local grub.cfg
 stringinstring ".grub.cfg" "$FILE" && EXT="grub-local"
 
+# recognize download request of start.conf-ip
+[[ ${FILE##$RSYNC_MODULE_PATH/} =~ start\.conf-[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]] && EXT="start.conf.gruppe"
+
 echo "HOSTNAME: $RSYNC_HOST_NAME"
 echo "RSYNC_REQUEST: $RSYNC_REQUEST"
 echo "FILE: $FILE"
@@ -158,6 +161,14 @@ case $EXT in
   startconf="$LINBODIR/start.conf.$group"
   append="$(linbo_kopts "$startconf") localboot"
   sed -e "s|linux \$linbo_kernel .*|linux \$linbo_kernel $append|g" "$grubcfg_tpl" > "$FILE"
+ ;;
+
+ # create download link start.conf-ip
+ start.conf.gruppe)
+  dhcp_cache="host_${FILE##*-}"
+  group="$(cat ${DHCPDCACHE}/${dhcp_cache} |grep 'option extensions-path ' | awk '{ print $3 }' | sed -e 's/"//g' -e 's/;//g' )"
+  echo "Gruppe: $group create link to $FILE"
+  [[ -n $group ]] && ln -sf "$LINBODIR/start.conf.$group" "$FILE"
  ;;
 
  *) ;;

--- a/files/lmn7/usr/share/linuxmuster/linbo/rsync-post-download.sh
+++ b/files/lmn7/usr/share/linuxmuster/linbo/rsync-post-download.sh
@@ -46,6 +46,9 @@ fi
 # recognize download request of local grub.cfg
 stringinstring ".grub.cfg" "$FILE" && EXT="grub-local"
 
+# recognize download request of start.conf-ip
+[[ ${FILE##$RSYNC_MODULE_PATH/} =~ start\.conf-[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]] && EXT="start.conf.gruppe"
+
 case $EXT in
 
  # remove linbocmd file after download
@@ -167,6 +170,12 @@ case $EXT in
    echo "Removing $FILE."
    rm -f "$FILE"
   fi
+ ;;
+
+ # remove download link start.conf-ip
+ start.conf.gruppe)
+  echo "remove link to $FILE"
+  [[ -L $FILE ]] && rm -f "$FILE"
  ;;
 
  *) ;;

--- a/files/lmn7/usr/share/linuxmuster/linbo/rsync-pre-download.sh
+++ b/files/lmn7/usr/share/linuxmuster/linbo/rsync-pre-download.sh
@@ -30,6 +30,9 @@ stringinstring "winact.tar.gz.upload" "$FILE" && EXT="winact-upload"
 # recognize download request of local grub.cfg
 stringinstring ".grub.cfg" "$FILE" && EXT="grub-local"
 
+# recognize download request of start.conf-ip
+[[ ${FILE##$RSYNC_MODULE_PATH/} =~ start\.conf-[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} ]] && EXT="start.conf.gruppe"
+
 echo "HOSTNAME: $RSYNC_HOST_NAME"
 echo "RSYNC_REQUEST: $RSYNC_REQUEST"
 echo "FILE: $FILE"
@@ -153,6 +156,14 @@ case $EXT in
   startconf="$LINBODIR/start.conf.$group"
   append="$(linbo_kopts "$startconf") localboot"
   sed -e "s|linux \$linbo_kernel .*|linux \$linbo_kernel $append|g" "$grubcfg_tpl" > "$FILE"
+ ;;
+
+ # create download link start.conf-ip
+ start.conf.gruppe)
+  dhcp_cache="host_${FILE##*-}"
+  group="$(cat ${DHCPDCACHE}/${dhcp_cache} |grep 'option extensions-path ' | awk '{ print $3 }' | sed -e 's/"//g' -e 's/;//g' )"
+  echo "Gruppe: $group create link to $FILE"
+  [[ -n $group ]] && ln -sf "$LINBODIR/start.conf.$group" "$FILE"
  ;;
 
  *) ;;


### PR DESCRIPTION
All the download links start.conf-ip fill the var/linbo directory, especially if you have a lot of hosts in the network. This patch for rsync-pre-download.sh and rsync-post-download.sh creates and removes this links on the fly from information in DHCPDCACHE/host_ip.

Maybe this patch needs to be reworked for lmn7, if this files are no longer used.

linuxmuster-base/import_workstations does not need to create the links any more.