### PR TITLE
tell hwclock to assume rtc is in utc

### DIFF
--- a/linbofs/init.sh
+++ b/linbofs/init.sh
@@ -620,7 +620,7 @@ network(){
    echo "Network connection to $server established successfully."
    grep ^[a-z] /tmp/dhcp.log | sed -e 's|^|local |g' > /tmp/network.ok
    echo "Starting time sync ..."
-   ( ntpd -n -q -p "$server" && hwclock --systohc ) &
+   ( ntpd -n -q -p "$server" && hwclock --utc --systohc ) &
    #date
    # linbo update & grub installation
    do_linbo_update "$server"


### PR DESCRIPTION
RTC should be in UTC (not in localtime, like Windows uses it).
hwclock on ubuntu writes RTC in UTC; busybox-hwclock seems to write in localtime (can't figure out, why). see https://ask.linuxmuster.net/t/probleme-mit-der-systemzeit-im-zusammenhang-mit-linbo-und-dem-lmn-bionic-cloop/5504