### PR TITLE
"wipe" command to overwrite existing partition data

### DIFF
--- a/files/lmn6/var/linbo/examples/start.conf.opensuse
+++ b/files/lmn6/var/linbo/examples/start.conf.opensuse
@@ -14,6 +14,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.remote_cache
+++ b/files/lmn6/var/linbo/examples/start.conf.remote_cache
@@ -13,6 +13,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.ubuntu
+++ b/files/lmn6/var/linbo/examples/start.conf.ubuntu
@@ -14,6 +14,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.ubuntu-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.ubuntu-efi
@@ -15,6 +15,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.ubuntu-opensuse-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.ubuntu-opensuse-efi
@@ -16,6 +16,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win10
+++ b/files/lmn6/var/linbo/examples/start.conf.win10
@@ -13,6 +13,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win10-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win10-efi
@@ -15,6 +15,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win10-ubuntu
+++ b/files/lmn6/var/linbo/examples/start.conf.win10-ubuntu
@@ -16,6 +16,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win10-ubuntu-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win10-ubuntu-efi
@@ -17,6 +17,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win10-win10-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win10-win10-efi
@@ -16,6 +16,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win7
+++ b/files/lmn6/var/linbo/examples/start.conf.win7
@@ -13,6 +13,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win7-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win7-efi
@@ -15,6 +15,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win7-ubuntu
+++ b/files/lmn6/var/linbo/examples/start.conf.win7-ubuntu
@@ -16,6 +16,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win7-ubuntu-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win7-ubuntu-efi
@@ -17,6 +17,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/files/lmn6/var/linbo/examples/start.conf.win7-win7-efi
+++ b/files/lmn6/var/linbo/examples/start.conf.win7-win7-efi
@@ -16,6 +16,7 @@ RootTimeout = 600                   # logout from admin console after 600 secs
 AutoPartition = no                  # no partition repair during LINBO startup
 AutoFormat = no                     # no formatting of all partitions during LINBO startup
 AutoInitCache = no                  # no initial cache setup during LINBO startup
+AutoFix = no                        # try to fix dirty bit before mount
 DownloadType = torrent              # image download method (torrent|multicast|rsync)
 BackgroundFontColor = white         # font color of status section (default: white)
 ConsoleFontColorStdout = lightgreen # console font color (default: white)

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -749,6 +749,7 @@ convert_size(){
  echo $size
 }
 
+# thoschi
 # there are some problems with existing labels, so the new command "wipe" (that does just some dding) might help  
 wipe(){
  local RC=0

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -749,6 +749,15 @@ convert_size(){
  echo $size
 }
 
+# there are some problems with existing labels, so the new command "wipe" (that does just some dding) might help  
+wipe(){
+ local table="$1"
+ [ -s "$table" ] || return 1
+ local disk="/dev/$(basename "$table")"
+ [ -b "$disk" ] || return 1
+ dd if=/dev/zero of=$disk bs=512 count=1
+}
+
 # partition with parted, invoked by partition() for each disk
 # args: table
 mk_parted(){
@@ -944,6 +953,8 @@ partition(){
   fi
   case "$line" in dev=*|label=*|id=*|fstype=*|size=*|bootable=*) eval "$line" ;; esac
  done
+
+ # remove all partition information from disk (to 
 
  # get all disks from start.conf
  local disks="$(get_disks_startconf)"
@@ -3531,6 +3542,7 @@ case "$cmd" in
  update) update "$@" ;;
  upload) upload "$@" ;;
  version) version ;;
+ wipe) wipe "$@" ;;
  writefile) writefile "$@" ;;
  *) help "$cmd" "$@" ;;
 esac

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -552,6 +552,9 @@ mountpart(){
  type="$(fstype $1)"
  case "$type" in
   *ntfs*)
+   # check for dirty bit (if autofix is set in start.conf and ntfsfix returns error
+   [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }') == 1 ] && /bin/ntfsfix -n "$mountdev"; RC="$?"
+   [ "$RC" = "1" ] && /bin/ntfsfix "$mountdev"
    OPTS="$OPTS,recover,remove_hiberfile,user_xattr,inherit,acl"
    #ntfs-3g "$1" "$2" -o "$OPTS" 2>/dev/null; RC="$?"
    ;;

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -552,8 +552,8 @@ mountpart(){
  type="$(fstype $1)"
  case "$type" in
   *ntfs*)
-   # check for dirty bit (if autofix is set in start.conf and ntfsfix returns error
-   [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }') == 1 ] && /bin/ntfsfix -n "$mountdev"; RC="$?"
+   # thoschi - check for dirty bit (if autofix is set in start.conf and ntfsfix returns error
+   [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }' | tr A-Z a-z) == "yes" ] && /bin/ntfsfix -n "$mountdev"; RC="$?"
    [ "$RC" = "1" ] && /bin/ntfsfix "$mountdev"
    OPTS="$OPTS,recover,remove_hiberfile,user_xattr,inherit,acl"
    #ntfs-3g "$1" "$2" -o "$OPTS" 2>/dev/null; RC="$?"

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -553,8 +553,12 @@ mountpart(){
  case "$type" in
   *ntfs*)
    # thoschi - check for dirty bit (if autofix is set in start.conf and ntfsfix returns error
-   [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }' | tr A-Z a-z) == "yes" ] && /bin/ntfsfix -n "$mountdev"; RC="$?"
-   [ "$RC" = "1" ] && /bin/ntfsfix "$mountdev"
+   if [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }' | tr A-Z a-z) == "yes" ]; then
+     if [ "$(ntfs-3g "$mountdev" "$2" 2>&1 >/dev/null | grep -c "unclean"; umount "$mountdev")" == "1" ]; then
+       /bin/ntfsfix "$mountdev"
+       echo "Dirty-Bit auf $mountdev wurde entfernt!" | tee -a /tmp/linbo.log
+     fi
+   fi
    OPTS="$OPTS,recover,remove_hiberfile,user_xattr,inherit,acl"
    #ntfs-3g "$1" "$2" -o "$OPTS" 2>/dev/null; RC="$?"
    ;;

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -555,7 +555,7 @@ mountpart(){
    # thoschi - check for dirty bit (if autofix is set in start.conf and ntfsfix returns error
    if [ $(grep -i ^autofix /start.conf | tail -1 | awk -F= '{ print $2 }' | awk '{ print $1 }' | tr A-Z a-z) == "yes" ]; then
      if [ "$(ntfs-3g "$mountdev" "$2" 2>&1 >/dev/null | grep -c "unclean"; umount "$mountdev")" == "1" ]; then
-       /bin/ntfsfix "$mountdev"
+       /bin/ntfsfix "$mountdev" &> /dev/null
        echo "Dirty-Bit auf $mountdev wurde entfernt!" | tee -a /tmp/linbo.log
      fi
    fi

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -751,11 +751,13 @@ convert_size(){
 
 # there are some problems with existing labels, so the new command "wipe" (that does just some dding) might help  
 wipe(){
- local table="$1"
- [ -s "$table" ] || return 1
- local disk="/dev/$(basename "$table")"
+ local RC=0
+ local disks="$(get_disks_startconf)"
  [ -b "$disk" ] || return 1
- dd if=/dev/zero of=$disk bs=512 count=1
+ for disk in $disks; do
+  dd if=/dev/zero of=$disk bs=512 count=1 || RC=1
+ done
+ return "$RC"
 }
 
 # partition with parted, invoked by partition() for each disk

--- a/linbofs/usr/bin/linbo_wrapper
+++ b/linbofs/usr/bin/linbo_wrapper
@@ -293,6 +293,7 @@ help(){
  echo
  echo "Verfügbare Befehle sind:"
  echo
+ echo "wipe                     : Überschreiben alter Partitionsinformationen."
  echo "partition                : Schreibe die Partitionstabelle."
  echo "label                    : Versieht alle Partitionen mit Label, die in der"
  echo "                           start.conf-Datei definiert und formatiert sind."
@@ -345,6 +346,10 @@ while [ "$#" -gt "0" ]; do
   linbo)
    echo "${cmd}:${param}" > "$SECRETS"
    ;;
+
+  wipe)
+   linbo_cmd wipe
+  ;;
 
   partition)
    get_partitions


### PR DESCRIPTION
a new command "wipe" will call dd to overwrite any existing partition data
this deals with the label error discussed in ask