### PR TITLE
PID of screen launched

### DIFF
--- a/files/lmn7/usr/share/linuxmuster/linbo/linbo-remote.sh
+++ b/files/lmn7/usr/share/linuxmuster/linbo/linbo-remote.sh
@@ -457,9 +457,9 @@ send_cmds(){
   chmod 755 $REMOTESCRIPT
 
   # start script in screen session
-  screen -dmS $HOSTNAME.linbo-remote $REMOTESCRIPT
+  screen -DmS $HOSTNAME.linbo-remote $REMOTESCRIPT &
 
-  echo "Ok!"
+  echo "Ok! (PID $!)"
  done
 }
 


### PR DESCRIPTION
I always must do a `linbo-remote -l` to get the PID of the screen launched, and then I can follow the result of the command with `screen -r PID`
So this little PR is just here to already print the PID of the screen in background.