### PR TITLE
Fix issues with capital letters in hostname and log/status files

### DIFF
--- a/files/lmn7/usr/share/linuxmuster/linbo/rsync-pre-download.sh
+++ b/files/lmn7/usr/share/linuxmuster/linbo/rsync-pre-download.sh
@@ -68,7 +68,7 @@ case $EXT in
   *.log)
     host_logfile="$(basename "$FILE")"
     echo "Upload request for $host_logfile."
-    src_logfile="$(echo "$FILE" | sed -e "s|$LINBODIR/tmp/${compname}_|/tmp/|")"
+    src_logfile="$(echo "$FILE" | sed -e "s|$LINBODIR/tmp/${compname}_|/tmp/|I")"
     tgt_logfile="$LINBOLOGDIR/$host_logfile"
     linbo-scp -v "${RSYNC_HOST_ADDR}:$src_logfile" "$FILE" || RC="1"
     if [ -s "$FILE" ]; then
@@ -84,7 +84,7 @@ case $EXT in
   *.status)
     host_logfile="$(basename "$FILE")"
     echo "Upload request for $host_logfile."
-    src_logfile="$(echo "$FILE" | sed -e "s|$LINBODIR/tmp/${compname}_|/tmp/|")"
+    src_logfile="$(echo "$FILE" | sed -e "s|$LINBODIR/tmp/${compname}_|/tmp/|I")"
     tgt_logfile="$LINBOLOGDIR/$host_logfile"
     linbo-scp -v "${RSYNC_HOST_ADDR}:$src_logfile" "$FILE" || RC="1"
     if [ -s "$FILE" ]; then


### PR DESCRIPTION
This fixes the issue that logfiles and status files cannot be pulled from clients which have a hostname with capital letters.
Fixes #182 